### PR TITLE
Adjacent at 180º

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -70,7 +70,7 @@ func CalculateAdjacent(s, dir string) string {
 	}
 	// base := s[0:]
 	base := s[:(len(s) - 1)]
-	if strings.Index(borders[dirInt][oddEven], lastChr) != -1 {
+	if strings.Index(borders[dirInt][oddEven], lastChr) != -1 && len(base) > 0 {
 		base = CalculateAdjacent(base, dir)
 	}
 	return base + string(base32[strings.Index(neighbors[dirInt][oddEven], lastChr)])

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -1,6 +1,10 @@
 package geohash
 
-import "testing"
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 type geohashTest struct {
 	input  string
@@ -102,65 +106,61 @@ func TestEncode(t *testing.T) {
 	}
 }
 
-type adjacentTest struct {
-	geohash string
-	dir string
-	adjacent string
-}
-
 func TestCalculateAdjacent(t *testing.T) {
-	var tests = []adjacentTest{
-		adjacentTest {
-			geohash: "zbzury",
-			dir: "right",
+	for _, test := range []struct {
+		geohash  string
+		dir      string
+		adjacent string
+	}{
+		{
+			geohash:  "zbzury",
+			dir:      "right",
 			adjacent: "b0bh2n",
 		},
-		adjacentTest {
-			geohash: "b0bh2n",
-			dir: "bottom",
+		{
+			geohash:  "b0bh2n",
+			dir:      "bottom",
 			adjacent: "b0bh2j",
 		},
-		adjacentTest {
-			geohash: "b0bh2j",
-			dir: "left",
+		{
+			geohash:  "b0bh2j",
+			dir:      "left",
 			adjacent: "zbzurv",
 		},
-		adjacentTest {
-			geohash: "zbzurv",
-			dir: "left",
+		{
+			geohash:  "zbzurv",
+			dir:      "left",
 			adjacent: "zbzurt",
 		},
-		adjacentTest {
-			geohash: "zbzurt",
-			dir: "up",
+		{
+			geohash:  "zbzurt",
+			dir:      "up",
 			adjacent: "zbzurw",
 		},
-		adjacentTest {
-			geohash: "zbzurw",
-			dir: "up",
+		{
+			geohash:  "zbzurw",
+			dir:      "up",
 			adjacent: "zbzurx",
 		},
-		adjacentTest {
-			geohash: "zbzurx",
-			dir: "right",
+		{
+			geohash:  "zbzurx",
+			dir:      "right",
 			adjacent: "zbzurz",
 		},
-		adjacentTest {
-			geohash: "zbzurz",
-			dir: "right",
+		{
+			geohash:  "zbzurz",
+			dir:      "right",
 			adjacent: "b0bh2p",
 		},
-		adjacentTest {
-			geohash: "b0bh2p",
-			dir: "bottom",
+		{
+			geohash:  "b0bh2p",
+			dir:      "bottom",
 			adjacent: "b0bh2n",
 		},
-	}
-
-	for _, test := range tests {
-		adjacent := CalculateAdjacent(test.geohash, test.dir)
-		if test.adjacent != adjacent {
-			t.Errorf("expected %s, got %s", test.adjacent, adjacent)
-		}
+	} {
+		t.Run(fmt.Sprintf("%s -> %s -> %s", test.geohash, test.dir, test.adjacent), func(t *testing.T) {
+			adjacent := CalculateAdjacent(test.geohash, test.dir)
+			assert.Equal(t, test.adjacent, adjacent)
+		})
 	}
 }

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -101,3 +101,66 @@ func TestEncode(t *testing.T) {
 		}
 	}
 }
+
+type adjacentTest struct {
+	geohash string
+	dir string
+	adjacent string
+}
+
+func TestCalculateAdjacent(t *testing.T) {
+	var tests = []adjacentTest{
+		adjacentTest {
+			geohash: "zbzury",
+			dir: "right",
+			adjacent: "b0bh2n",
+		},
+		adjacentTest {
+			geohash: "b0bh2n",
+			dir: "bottom",
+			adjacent: "b0bh2j",
+		},
+		adjacentTest {
+			geohash: "b0bh2j",
+			dir: "left",
+			adjacent: "zbzurv",
+		},
+		adjacentTest {
+			geohash: "zbzurv",
+			dir: "left",
+			adjacent: "zbzurt",
+		},
+		adjacentTest {
+			geohash: "zbzurt",
+			dir: "up",
+			adjacent: "zbzurw",
+		},
+		adjacentTest {
+			geohash: "zbzurw",
+			dir: "up",
+			adjacent: "zbzurx",
+		},
+		adjacentTest {
+			geohash: "zbzurx",
+			dir: "right",
+			adjacent: "zbzurz",
+		},
+		adjacentTest {
+			geohash: "zbzurz",
+			dir: "right",
+			adjacent: "b0bh2p",
+		},
+		adjacentTest {
+			geohash: "b0bh2p",
+			dir: "bottom",
+			adjacent: "b0bh2n",
+		},
+	}
+
+	for _, test := range tests {
+		adjacent := CalculateAdjacent(test.geohash, test.dir)
+		if test.adjacent != adjacent {
+			t.Errorf("expectd %s, got %s", test.adjacent, adjacent)
+		}
+	}
+}

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -160,7 +160,7 @@ func TestCalculateAdjacent(t *testing.T) {
 	for _, test := range tests {
 		adjacent := CalculateAdjacent(test.geohash, test.dir)
 		if test.adjacent != adjacent {
-			t.Errorf("expectd %s, got %s", test.adjacent, adjacent)
+			t.Errorf("expected %s, got %s", test.adjacent, adjacent)
 		}
 	}
 }


### PR DESCRIPTION
During some testing calculating geohashes for locations at `[50, 180]` we found some exceptions.

This fixed that problem, I've got inspiration on Elixir/Python/Ruby implementations:

https://github.com/polmuz/elixir-geohash/blob/584deeb521bf89dbd2549c1a61b780f108bc32e5/lib/geohash.ex#L241-L264

https://github.com/transitland/mapzen-geohash/blob/5264d16dc2df00ebc4aedaa78ca8c6ee3fd655ad/mzgeohash/geohash.py#L84-L108

https://github.com/creasty/geohash_ruby/blob/d20d69a8ce67a2fc6277388dfef4336cc1d4ed40/lib/geohash_ruby.rb#L136-L148

